### PR TITLE
Expose xhr to resolve, fixes #17

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Chris DeLuca <bronzehedwick@gmail.com>
 Firtina Ozbalikci <firtina14@gmail.com>
 James Cleveland <jc@blit.cc>
+Jordan Stephens <jordan@stephens.io>
 Matt Bilbow <hello@mattbilbow.co.uk>
 Tom Byrer <tomByrer@gmail.com>
 Will Prater <will@superformula.com>

--- a/src/xr.js
+++ b/src/xr.js
@@ -42,8 +42,20 @@ function res(xhr) {
   return {
     status: xhr.status,
     response: xhr.response,
-    xhr: xhr
+    xhr
   };
+}
+
+function xhrData(xhr, opts) {
+  if (xhr.responseText) {
+    if (opts.raw === true) {
+      return xhr.responseText;
+    } else {
+      return opts.load(xhr.responseText);
+    }
+  } else {
+    return null;
+  }
 }
 
 function assign(l, ...rs) {
@@ -96,13 +108,9 @@ function xr(args) {
 
     xhr.addEventListener(Events.LOAD, () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        let data = null;
-        if (xhr.responseText) {
-          data = opts.raw === true
-            ? xhr.responseText
-            : opts.load(xhr.responseText);
-        }
-        resolve(data);
+        resolve(assign({}, res(xhr), {
+          data: xhrData(xhr, opts)
+        }));
       } else {
         reject(res(xhr));
       }

--- a/xr.js
+++ b/xr.js
@@ -64,6 +64,18 @@
     };
   }
 
+  function xhrData(xhr, opts) {
+    if (xhr.responseText) {
+      if (opts.raw === true) {
+        return xhr.responseText;
+      } else {
+        return opts.load(xhr.responseText);
+      }
+    } else {
+      return null;
+    }
+  }
+
   function assign(l) {
     for (var _len = arguments.length, rs = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
       rs[_key - 1] = arguments[_key];
@@ -109,11 +121,9 @@
 
       xhr.addEventListener(Events.LOAD, function () {
         if (xhr.status >= 200 && xhr.status < 300) {
-          var _data = null;
-          if (xhr.responseText) {
-            _data = opts.raw === true ? xhr.responseText : opts.load(xhr.responseText);
-          }
-          resolve(_data);
+          resolve(assign({}, res(xhr), {
+            data: xhrData(xhr, opts)
+          }));
         } else {
           reject(res(xhr));
         }


### PR DESCRIPTION
I went ahead and forked this for my own purposes to fix #17.

Note that this does change the public API. The value passed to `then` is no longer only the response body. It is now an object with three properties: `status`, `data`, and `xhr`. This is the same format as the value which is passed on a rejected promise.

For example:

``` javascript
xr.get(url).then(function(response) {
  console.log(response); // => Object {status: 200, data: Object, xhr: XMLHttpRequest}
});
```

Let me know if you're interested in merging this and I can make any further changes that you might like, update the README, etc. 

Thanks!
