### PR TITLE
Removing Object.assign dependency from README, closes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Requirements
 ------------
 
 There must be a [polyfill](https://github.com/jakearchibald/es6-promise) or [browser](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Browser_compatibility) that supports at least the standard ES6 promise API
-(xr will use whatever's there), and `[Object.assign()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)'.
+(xr will use whatever's there).
 
 License
 -------


### PR DESCRIPTION
Answering my own question from #16, I found in the [CHANGELOG](https://github.com/radiosilence/xr/blob/master/CHANGELOG.md#013) that it is indeed no longer used and was removed in v0.1.3. So I'm removing it from the README.
