### PR TITLE
Add npm install information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ It's lightweight, has no dependencies (other than having either Promise
 in the global namespace or provided via `xr.config`), and adds pretty
 much no overhead over the standard XHR API.
 
+Install
+----------
+`npm install xr --save`
+
 Quickstart
 ----------
 


### PR DESCRIPTION
Saw there is not mention how to install this project with `npm`, i'm always happy if i see the npm package-name on the github-repo, so i don't have to look on npm if the name is the same (or if it's published?)
So what do you think if we implement it there too?
