### PR TITLE
Set timeout

### DIFF
--- a/src/xr.js
+++ b/src/xr.js
@@ -38,6 +38,7 @@ const defaults = {
   xmlHttpRequest: () => new XMLHttpRequest(),
   promise: fn => new Promise(fn),
   withCredentials: false,
+  timeout: 0,
 };
 
 function res(xhr, data) {
@@ -96,6 +97,8 @@ function xr(args) {
         : opts.url,
       true
     );
+
+    xhr.timeout = opts.timeout;
 
     xhr.addEventListener(Events.LOAD, () => {
       if (xhr.status >= 200 && xhr.status < 300) {


### PR DESCRIPTION
Setting the XHR timeout (in milliseconds) can only be done after the `open()` method in [versions of Internet Explorer](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout). Thus, the workaround approach to creating your own XHR to pass in for `opts.xmlHttpRequest` doesn't work since `open` is called afterwards.

This is also cleaner than creating a custom XHR for each time you'd like to `xr.get` with a more aggressive timeout.
