### PR TITLE
Add compatibility with IE versions <= 10

### DIFF
--- a/src/xr.js
+++ b/src/xr.js
@@ -80,8 +80,6 @@ function xr(args) {
     const opts = assign({}, defaults, config, args);
     const xhr = opts.xmlHttpRequest();
 
-    xhr.withCredentials = opts.withCredentials;
-
     if (opts.abort) {
       args.abort(() => {
         reject(res(xhr));
@@ -96,6 +94,9 @@ function xr(args) {
         : opts.url,
       true
     );
+
+    // setting after open for compatibility with IE versions <=10
+    xhr.withCredentials = opts.withCredentials;
 
     xhr.addEventListener(Events.LOAD, () => {
       if (xhr.status >= 200 && xhr.status < 300) {


### PR DESCRIPTION
This PR sets the `XmlHttpRequest` object's `withCredentials` property AFTER calling the `open` method, instead of before.

Doing so allows this library to be used with IE versions <= 10. Previous to IE11, Internet Explorer would throw an `InvalidStateError` if the `withCredentials` property was set before calling the open method.

Setting `withCredentials` after the `open` call is equally standards compliant.

> 1. If state is not unsent or opened, throw an InvalidStateError exception. 
> 2. If the send() flag is set, throw an InvalidStateError exception. 
> 
> https://xhr.spec.whatwg.org/#the-withcredentials-attribute

In other words, you can set it before opening an XHR, or after opening but before sending. And indeed, in other browsers (Chrome, Firefox, Safari), either method works equally well.

This is a known IE bug, and this PR's fix has been used effectively in other projects, for example: https://github.com/enyo/dropzone/issues/179
